### PR TITLE
fix: protocol undefined error when call trim_whitespaces/1

### DIFF
--- a/lib/valicon/conversions.ex
+++ b/lib/valicon/conversions.ex
@@ -123,7 +123,7 @@ defmodule Valicon.Conversions do
   defp stringify_key({key, value}, acc), do: Map.put(acc, key, value)
 
   @spec trim_whitespaces(any()) :: any()
-  def trim_whitespaces(input) when is_map(input),
+  def trim_whitespaces(input) when is_non_struct_map(input),
     do: Enum.into(input, %{}, fn {k, v} -> {k, trim_whitespaces(v)} end)
 
   def trim_whitespaces(input) when is_binary(input), do: String.trim(input)

--- a/test/lib/valicon/conversions_test.exs
+++ b/test/lib/valicon/conversions_test.exs
@@ -204,6 +204,15 @@ defmodule Valicon.ConversionsTest do
                }
              } == trim_whitespaces(map)
     end
+
+    test "ignores date/datetime/naivedatime structs" do
+      dates = [~D[2025-02-18], ~U[2025-02-18 17:07:46.225776Z], ~N[2025-02-27 16:35:04.065640]]
+
+      for value <- dates do
+        assert %{inserted_at: ^value, name: "John Doe"} =
+                 trim_whitespaces(%{inserted_at: value, name: " John Doe   "})
+      end
+    end
   end
 
   describe "upcase_in/2" do


### PR DESCRIPTION
When calling the `trim_whitespace/1` with a custom map including a `NaiveDateTime` value the following error was raised.

```elixir
** (Protocol.UndefinedError) protocol Enumerable not implemented for ~N[2025-02-27 16:35:04.065640] of type NaiveDateTime (a struct). 
```

Replacing the `is_map/1` by the [`is_non_struct_map/1`](https://hexdocs.pm/elixir/Kernel.html#is_non_struct_map/1) will prevent the error happen again.

Extra References: 
https://hexdocs.pm/elixir/Kernel.html#is_map/1