### PR TITLE
fix: protocol undefind error on validate_uuid/2

### DIFF
--- a/lib/valicon/validations.ex
+++ b/lib/valicon/validations.ex
@@ -248,7 +248,7 @@ defmodule Valicon.Validations do
   defp validate_uuid(_key, nil), do: []
 
   defp validate_uuid(key, value) when not is_binary(value),
-    do: [ValidationError.new("#{key}", "#{key} must be a UUID (value: #{value})")]
+    do: [ValidationError.new("#{key}", "#{key} must be a UUID")]
 
   defp validate_uuid(key, value) do
     if String.match?(value, @uuid_regex) do
@@ -257,7 +257,7 @@ defmodule Valicon.Validations do
       [
         ValidationError.new(
           "#{key}",
-          "#{key} must be a UUID (value: #{value})"
+          "#{key} must be a UUID"
         )
       ]
     end

--- a/test/lib/valicon/validations_test.exs
+++ b/test/lib/valicon/validations_test.exs
@@ -281,18 +281,26 @@ defmodule Valicon.ValidationsTest do
 
       assert [
                %Valicon.ValidationError{
-                 message: "id must be a UUID (value: 123)",
+                 message: "id must be a UUID",
                  path: "id"
                }
              ] == validate_uuid_fields(%{@attrs | id: "123"}, ~w[id]a)
 
       assert [
                %Valicon.ValidationError{
-                 message: "id must be a UUID (value: 12)",
+                 message: "id must be a UUID",
                  path: "id"
                }
              ] ==
                validate_uuid_fields(%{@attrs | id: 12}, ~w[id]a)
+
+      assert [
+               %Valicon.ValidationError{
+                 message: "id must be a UUID",
+                 path: "id"
+               }
+             ] ==
+               validate_uuid_fields(%{@attrs | id: %{id: 12}}, ~w[id]a)
     end
   end
 


### PR DESCRIPTION
** (Protocol.UndefinedError) protocol String.Chars not implemented for type Map. This protocol is implemented for the following type(s): Atom, BitString, Date, DateTime, Decimal, Float, Integer, List, NaiveDateTime, Pfx, Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.Query, RemoteIp.Block, Time, URI, Version, Version.Requirement

Got value:

    %{"Instragram" => "86186a52-5222-4776-bb9a-30bfe7b8134c"}
